### PR TITLE
keep original model filename on .glb output

### DIFF
--- a/src/bin/model-to-gltf.rs
+++ b/src/bin/model-to-gltf.rs
@@ -772,7 +772,13 @@ fn main() -> io::Result<()> {
     // Write output
 
     let gltf_bytes = gltf.finish();
-    fs::write("out.glb", gltf_bytes)?;
+	let mut file_stem = model_path.file_stem();
+	let mut file_stem = file_stem.unwrap();
+	let fileName = format!("{}{}", file_stem.to_str().unwrap(), ".glb");
+
+    fs::write(fileName.clone(), gltf_bytes)?;
+	println!("Output Filename: {}", fileName);
+
 
 
     Ok(())


### PR DESCRIPTION
I feel like this could help keep things organized, especially for batch processing of multiple models